### PR TITLE
Added compatibility for Sony's official adapter

### DIFF
--- a/DS4Windows/DS4Library/DS4Devices.cs
+++ b/DS4Windows/DS4Library/DS4Devices.cs
@@ -16,7 +16,7 @@ namespace DS4Windows
         {
             lock (Devices)
             {
-                int[] pid = { 0x5C4 };
+                int[] pid = { 0xBA0, 0x5C4 };
                 IEnumerable<HidDevice> hDevices = HidDevices.Enumerate(0x054C, pid);
                 // Sort Bluetooth first in case USB is also connected on the same controller.
                 hDevices = hDevices.OrderBy<HidDevice, ConnectionType>((HidDevice d) => { return DS4Device.HidConnectionType(d); });


### PR DESCRIPTION
Updated the PID list so that the Sony's official Dualshock 4 wireless adapter works with DS4Windows. Sound via the Dualshock can be managed via windows playback and recording devices as per normal. 
