### PR TITLE
fixed several "repeat while held" macro issues

### DIFF
--- a/DS4Windows/DS4Control/ScpUtil.cs
+++ b/DS4Windows/DS4Control/ScpUtil.cs
@@ -803,7 +803,7 @@ namespace DS4Windows
                                 keyType += DS4KeyType.Unbound;
                         if (dcs.keyType.HasFlag(DS4KeyType.HoldMacro))
                             keyType += DS4KeyType.HoldMacro;
-                        if (dcs.keyType.HasFlag(DS4KeyType.Macro))
+                        else if (dcs.keyType.HasFlag(DS4KeyType.Macro))
                             keyType += DS4KeyType.Macro;
                         if (dcs.keyType.HasFlag(DS4KeyType.Toggle))
                             keyType += DS4KeyType.Toggle;

--- a/DS4Windows/DS4Forms/KBM360.cs
+++ b/DS4Windows/DS4Forms/KBM360.cs
@@ -454,7 +454,7 @@ namespace DS4Windows
                         lBMacroOn.Visible = true;
                         foreach (int i in tag)
                             macrostag.Add(i);
-                    if (Global.GetDS4KeyType(device, button.Name, rBShiftModifer.Checked).HasFlag(DS4KeyType.RepeatMacro))
+                    if (Global.GetDS4KeyType(device, button.Name, rBShiftModifer.Checked).HasFlag(DS4KeyType.HoldMacro))
                         macrorepeat = true;
                 }
                 else if (tagO is string || tagO is X360Controls)

--- a/DS4Windows/DS4Forms/Options.cs
+++ b/DS4Windows/DS4Forms/Options.cs
@@ -1082,7 +1082,7 @@ namespace DS4Windows
             if (SC) kt |= DS4KeyType.ScanCode;
             if (TG) kt |= DS4KeyType.Toggle;
             if (MC) kt |= DS4KeyType.Macro;
-            if (MR) kt |= DS4KeyType.RepeatMacro;
+            if (MR) kt |= DS4KeyType.HoldMacro;
             UpdateDS4CSetting(device, ctrl.Name, shift, tag.Key, tag.Value, kt, sTrigger);
         }
 

--- a/DS4Windows/DS4Forms/RecordBox.cs
+++ b/DS4Windows/DS4Forms/RecordBox.cs
@@ -784,8 +784,7 @@ namespace DS4Windows
                     kbm.macrostag = macros;
                     kbm.macros = macronames;
                     kbm.lBMacroOn.Visible = true;
-                    if (cBStyle.SelectedIndex == 1)
-                        kbm.macrorepeat = true;
+                    kbm.macrorepeat = cBStyle.SelectedIndex == 1;
                     saved = true;
                     if (sender != kbm)
                         kbm.Close();
@@ -796,8 +795,7 @@ namespace DS4Windows
                     sA.macros = macronames;
                     sA.lbMacroRecorded.Text = string.Join(", ", macronames);
                     //kbm.lBMacroOn.Visible = true;
-                    if (cBStyle.SelectedIndex == 1)
-                        sA.macrorepeat = true;
+                    sA.macrorepeat = cBStyle.SelectedIndex == 1;
                     saved = true;
                     //if (sender != sA)
                     // sA.Close();


### PR DESCRIPTION
This should resolve #164 and #89. Works for me now at least. Without making any changes to the code, I could only get repeat while held macros to work by editing the profile's xml file with a text editor. 

There were 3 different issues that had to be fixed: 
1. The DS4KeyType flags HoldMacro and RepeatMacro seem to refer to the same feature, but some files use the former and other files use the latter. I changed all instances of RepeatMacro to HoldMacro to fix this. 
2. When saving the profile in ScpUtil.cs, the program would write "HoldMacro" if the hold macro flag is set, and "Macro" if the flag is set. Since both flags are set in the case of a HoldMacro, this results in "HoldMacroMacro" being written"  
3. In RecordBox.cs, the macrorepeat variable is not set to false if the user switches from "repeat while held" to "play once". This meant you could change a Macro to a HoldMacro, but not the other way around without editing the xml file.
