### PR TITLE
Allow full XInput axis range for sticks

### DIFF
--- a/DS4Windows/DS4Control/X360Device.cs
+++ b/DS4Windows/DS4Control/X360Device.cs
@@ -12,6 +12,8 @@ namespace DS4Windows
     {
         private const String DS3_BUS_CLASS_GUID = "{F679F562-3164-42CE-A4DB-E7DDBE723909}";
         private const int CONTROLLER_OFFSET = 1; // Device 0 is the virtual USB hub itself, and we leave devices 1-10 available for other software (like the Scarlet.Crush DualShock driver itself)
+        private const int inputResolution = 127 - (-128);
+        private const int outputResolution = 32767 - (-32768);
 
         private int firstController = 1;
         // Device 0 is the virtual USB hub itself, and we can leave more available for other software (like the Scarlet.Crush DualShock driver)
@@ -25,10 +27,10 @@ namespace DS4Windows
         {
             Value -= 0x80;
 
-            if (Value == -128) Value = -127;
-            if (Flip) Value *= -1;
+            float temp = (Value - (-128)) / (float)inputResolution;
+            if (Flip) temp = (temp - 0.5f) * -1.0f + 0.5f;
 
-            return (Int32)((float)Value * 258.00787401574803149606299212599f);
+            return (Int32)(temp * outputResolution + (-32768));
         }
 
 
@@ -133,9 +135,9 @@ namespace DS4Windows
             Output[13] = state.R2; // Right Trigger
 
             Int32 ThumbLX = Scale(state.LX, false);
-            Int32 ThumbLY = -Scale(state.LY, false);
+            Int32 ThumbLY = Scale(state.LY, true);
             Int32 ThumbRX = Scale(state.RX, false);
-            Int32 ThumbRY = -Scale(state.RY, false);
+            Int32 ThumbRY = Scale(state.RY, true);
             Output[14] = (Byte)((ThumbLX >> 0) & 0xFF); // LX
             Output[15] = (Byte)((ThumbLX >> 8) & 0xFF);            
             Output[16] = (Byte)((ThumbLY >> 0) & 0xFF); // LY


### PR DESCRIPTION
This change allows the full XInput axis range to be used for the analog sticks. This fixes the problem mentioned in issue #233.