### PR TITLE
Fix typo on value in Resources.rex

### DIFF
--- a/DS4Windows/Properties/Resources.resx
+++ b/DS4Windows/Properties/Resources.resx
@@ -263,7 +263,7 @@
     <value>Charging: *number*%</value>
   </data>
   <data name="ColorByBattery" xml:space="preserve">
-    <value>Color by Battey %</value>
+    <value>Color by Battery %</value>
   </data>
   <data name="Connecting" xml:space="preserve">
     <value>Connecting...</value>
@@ -296,7 +296,7 @@
     <value>Delete Profile?</value>
   </data>
   <data name="DimByBattery" xml:space="preserve">
-    <value>Dim by Battey %</value>
+    <value>Dim by Battery %</value>
   </data>
   <data name="Disconnected" xml:space="preserve">
     <value>Disconnected</value>


### PR DESCRIPTION
`Battey %` -> `Battery %`