### PR TITLE
Add support for Hori Wired Mini Gamepad

### DIFF
--- a/DS4Windows/DS4Library/DS4Device.cs
+++ b/DS4Windows/DS4Library/DS4Device.cs
@@ -422,19 +422,9 @@ namespace DS4Windows
                 cState.Circle = ((byte)inputReport[5] & (1 << 6)) != 0;
                 cState.Cross = ((byte)inputReport[5] & (1 << 5)) != 0;
                 cState.Square = ((byte)inputReport[5] & (1 << 4)) != 0;
-                cState.DpadUp = ((byte)inputReport[5] & (1 << 3)) != 0;
-                cState.DpadDown = ((byte)inputReport[5] & (1 << 2)) != 0;
-                cState.DpadLeft = ((byte)inputReport[5] & (1 << 1)) != 0;
-                cState.DpadRight = ((byte)inputReport[5] & (1 << 0)) != 0;
 
                 //Convert dpad into individual On/Off bits instead of a clock representation
-                byte dpad_state = 0;
-
-                dpad_state = (byte)(
-                ((cState.DpadRight ? 1 : 0) << 0) |
-                ((cState.DpadLeft ? 1 : 0) << 1) |
-	            ((cState.DpadDown ? 1 : 0) << 2) |
-                ((cState.DpadUp ? 1 : 0) << 3));
+                byte dpad_state = (byte)(inputReport[5] & 15);
 
                 switch (dpad_state)
                 {
@@ -446,7 +436,7 @@ namespace DS4Windows
                     case 5: cState.DpadUp = false; cState.DpadDown = true; cState.DpadLeft = true; cState.DpadRight = false; break;
                     case 6: cState.DpadUp = false; cState.DpadDown = false; cState.DpadLeft = true; cState.DpadRight = false; break;
                     case 7: cState.DpadUp = true; cState.DpadDown = false; cState.DpadLeft = true; cState.DpadRight = false; break;
-                    case 8: cState.DpadUp = false; cState.DpadDown = false; cState.DpadLeft = false; cState.DpadRight = false; break;
+                    default: cState.DpadUp = false; cState.DpadDown = false; cState.DpadLeft = false; cState.DpadRight = false; break;
                 }
 
                 cState.R3 = ((byte)inputReport[6] & (1 << 7)) != 0;

--- a/DS4Windows/HidLibrary/HidDevice.cs
+++ b/DS4Windows/HidLibrary/HidDevice.cs
@@ -340,8 +340,14 @@ namespace DS4Windows
             {
                 byte[] buffer = new byte[16];
                 buffer[0] = 18;
-                readFeatureData(buffer);                
-                serial =  String.Format("{0:X02}:{1:X02}:{2:X02}:{3:X02}:{4:X02}:{5:X02}", buffer[6], buffer[5], buffer[4], buffer[3], buffer[2], buffer[1]);
+                if (readFeatureData(buffer))
+                {
+                    serial = String.Format("{0:X02}:{1:X02}:{2:X02}:{3:X02}:{4:X02}:{5:X02}", buffer[6], buffer[5], buffer[4], buffer[3], buffer[2], buffer[1]);
+                }
+                else
+                {
+                    serial = String.Format("{0:X04}:{1:X04}:{2:X02}", _deviceAttributes.VendorId, _deviceAttributes.ProductId, _deviceAttributes.Version);
+                }
                 return serial;
             }
             else


### PR DESCRIPTION
Only a single  Hori Wired Mini Gamepad supported due to the way how the serial number is computed