### PR TITLE
Allow for EXE and appData save paths to be the same

### DIFF
--- a/DS4Windows/DS4Forms/DS4Form.cs
+++ b/DS4Windows/DS4Forms/DS4Form.cs
@@ -92,7 +92,8 @@ namespace DS4Windows
             SystemEvents.PowerModeChanged += OnPowerChange;
             tSOptions.Visible = false;
             bool firstrun = false;
-            if (File.Exists(exepath + "\\Auto Profiles.xml")
+            if (exepath != appDataPpath
+                && File.Exists(exepath + "\\Auto Profiles.xml")
                 && File.Exists(appDataPpath + "\\Auto Profiles.xml"))
             {
                 firstrun = true;


### PR DESCRIPTION
Simply edited in web interface with no testing, but the idea is if you save your EXEs in your appData path, it shouldn't trigger a multiple save dialog because the two paths are in fact the same.